### PR TITLE
Implement decompression without using Unsafe

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -11,7 +11,7 @@
     <name>aircompressor</name>
 
     <description>Compression algorithms</description>
-    <url>http://github.com/airlift/aircompressor</url>
+    <url>https://github.com/airlift/aircompressor</url>
 
     <parent>
         <groupId>io.airlift</groupId>
@@ -24,7 +24,7 @@
     <licenses>
         <license>
             <name>Apache License 2.0</name>
-            <url>http://www.apache.org/licenses/LICENSE-2.0.html</url>
+            <url>https://www.apache.org/licenses/LICENSE-2.0.html</url>
             <distribution>repo</distribution>
         </license>
     </licenses>
@@ -32,7 +32,7 @@
     <scm>
         <connection>scm:git:git://github.com/airlift/aircompressor.git</connection>
         <developerConnection>scm:git:git@github.com:airlift/aircompressor.git</developerConnection>
-        <url>http://github.com/airlift/aircompressor/tree/master</url>
+        <url>https://github.com/airlift/aircompressor/tree/master</url>
       <tag>HEAD</tag>
   </scm>
 

--- a/pom.xml
+++ b/pom.xml
@@ -37,8 +37,8 @@
   </scm>
 
     <properties>
-        <air.java.version>1.8</air.java.version>
-        <project.build.targetJdk>1.8</project.build.targetJdk>
+        <air.java.version>17</air.java.version>
+        <project.build.targetJdk>17</project.build.targetJdk>
         <air.check.skip-extended>true</air.check.skip-extended>
         <air.check.skip-license>false</air.check.skip-license>
         <air.check.fail-checkstyle>true</air.check.fail-checkstyle>

--- a/pom.xml
+++ b/pom.xml
@@ -37,10 +37,11 @@
   </scm>
 
     <properties>
-        <air.java.version>17</air.java.version>
-        <project.build.targetJdk>17</project.build.targetJdk>
+        <air.java.version>11</air.java.version>
+        <project.build.targetJdk>11</project.build.targetJdk>
         <air.check.skip-extended>true</air.check.skip-extended>
         <air.check.skip-license>false</air.check.skip-license>
+        <air.license.skip-existing-headers>true</air.license.skip-existing-headers>
         <air.check.fail-checkstyle>true</air.check.fail-checkstyle>
         <air.check.skip-checkstyle>false</air.check.skip-checkstyle>
 

--- a/src/main/java/io/airlift/compress/zstd/ZstdDecompressorBb.java
+++ b/src/main/java/io/airlift/compress/zstd/ZstdDecompressorBb.java
@@ -33,15 +33,7 @@ public class ZstdDecompressorBb
     public int decompress(byte[] input, int inputOffset, int inputLength, byte[] output, int outputOffset, int maxOutputLength)
             throws MalformedInputException
     {
-        verifyRange(input, inputOffset, inputLength);
-        verifyRange(output, outputOffset, maxOutputLength);
-
-        long inputAddress = ARRAY_BYTE_BASE_OFFSET + inputOffset;
-        long inputLimit = inputAddress + inputLength;
-        long outputAddress = ARRAY_BYTE_BASE_OFFSET + outputOffset;
-        long outputLimit = outputAddress + maxOutputLength;
-
-        return decompressor.decompress(input, inputAddress, inputLimit, output, outputAddress, outputLimit);
+        throw new IllegalArgumentException("Use ByteBuffer version of decompress() method");
     }
 
     @Override

--- a/src/main/java/io/airlift/compress/zstd/ZstdDecompressorBb.java
+++ b/src/main/java/io/airlift/compress/zstd/ZstdDecompressorBb.java
@@ -103,10 +103,10 @@ public class ZstdDecompressorBb
         }
     }
 
-    public static long getDecompressedSize(byte[] input, int offset, int length)
+    public static long getDecompressedSize(ByteBuffer input, int offset, int length)
     {
-        int baseAddress = ARRAY_BYTE_BASE_OFFSET + offset;
-        return ZstdFrameDecompressor.getDecompressedSize(input, baseAddress, baseAddress + length);
+        int baseAddress = offset;
+        return ZstdFrameDecompressorBb.getDecompressedSize(input, baseAddress, baseAddress + length);
     }
 
     private static void verifyRange(byte[] data, int offset, int length)

--- a/src/main/java/io/airlift/compress/zstd/ZstdDecompressorBb.java
+++ b/src/main/java/io/airlift/compress/zstd/ZstdDecompressorBb.java
@@ -1,0 +1,119 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.airlift.compress.zstd;
+
+import io.airlift.compress.Decompressor;
+import io.airlift.compress.MalformedInputException;
+
+import java.nio.Buffer;
+import java.nio.ByteBuffer;
+
+import static io.airlift.compress.zstd.UnsafeUtil.getAddress;
+import static java.lang.String.format;
+import static java.util.Objects.requireNonNull;
+import static sun.misc.Unsafe.ARRAY_BYTE_BASE_OFFSET;
+
+public class ZstdDecompressorBb
+        implements Decompressor
+{
+    private final ZstdFrameDecompressor decompressor = new ZstdFrameDecompressor();
+
+    @Override
+    public int decompress(byte[] input, int inputOffset, int inputLength, byte[] output, int outputOffset, int maxOutputLength)
+            throws MalformedInputException
+    {
+        verifyRange(input, inputOffset, inputLength);
+        verifyRange(output, outputOffset, maxOutputLength);
+
+        long inputAddress = ARRAY_BYTE_BASE_OFFSET + inputOffset;
+        long inputLimit = inputAddress + inputLength;
+        long outputAddress = ARRAY_BYTE_BASE_OFFSET + outputOffset;
+        long outputLimit = outputAddress + maxOutputLength;
+
+        return decompressor.decompress(input, inputAddress, inputLimit, output, outputAddress, outputLimit);
+    }
+
+    @Override
+    public void decompress(ByteBuffer inputBuffer, ByteBuffer outputBuffer)
+            throws MalformedInputException
+    {
+        // Java 9+ added an overload of various methods in ByteBuffer. When compiling with Java 11+ and targeting Java 8 bytecode
+        // the resulting signatures are invalid for JDK 8, so accesses below result in NoSuchMethodError. Accessing the
+        // methods through the interface class works around the problem
+        // Sidenote: we can't target "javac --release 8" because Unsafe is not available in the signature data for that profile
+        Buffer input = inputBuffer;
+        Buffer output = outputBuffer;
+
+        Object inputBase;
+        long inputAddress;
+        long inputLimit;
+        if (input.isDirect()) {
+            inputBase = null;
+            long address = getAddress(input);
+            inputAddress = address + input.position();
+            inputLimit = address + input.limit();
+        }
+        else if (input.hasArray()) {
+            inputBase = input.array();
+            inputAddress = ARRAY_BYTE_BASE_OFFSET + input.arrayOffset() + input.position();
+            inputLimit = ARRAY_BYTE_BASE_OFFSET + input.arrayOffset() + input.limit();
+        }
+        else {
+            throw new IllegalArgumentException("Unsupported input ByteBuffer implementation " + input.getClass().getName());
+        }
+
+        Object outputBase;
+        long outputAddress;
+        long outputLimit;
+        if (output.isDirect()) {
+            outputBase = null;
+            long address = getAddress(output);
+            outputAddress = address + output.position();
+            outputLimit = address + output.limit();
+        }
+        else if (output.hasArray()) {
+            outputBase = output.array();
+            outputAddress = ARRAY_BYTE_BASE_OFFSET + output.arrayOffset() + output.position();
+            outputLimit = ARRAY_BYTE_BASE_OFFSET + output.arrayOffset() + output.limit();
+        }
+        else {
+            throw new IllegalArgumentException("Unsupported output ByteBuffer implementation " + output.getClass().getName());
+        }
+
+        // HACK: Assure JVM does not collect Slice wrappers while decompressing, since the
+        // collection may trigger freeing of the underlying memory resulting in a segfault
+        // There is no other known way to signal to the JVM that an object should not be
+        // collected in a block, and technically, the JVM is allowed to eliminate these locks.
+        synchronized (input) {
+            synchronized (output) {
+                int written = decompressor.decompress(inputBase, inputAddress, inputLimit, outputBase, outputAddress, outputLimit);
+                output.position(output.position() + written);
+            }
+        }
+    }
+
+    public static long getDecompressedSize(byte[] input, int offset, int length)
+    {
+        int baseAddress = ARRAY_BYTE_BASE_OFFSET + offset;
+        return ZstdFrameDecompressor.getDecompressedSize(input, baseAddress, baseAddress + length);
+    }
+
+    private static void verifyRange(byte[] data, int offset, int length)
+    {
+        requireNonNull(data, "data is null");
+        if (offset < 0 || length < 0 || offset + length > data.length) {
+            throw new IllegalArgumentException(format("Invalid offset or length (%s, %s) in array of length %s", offset, length, data.length));
+        }
+    }
+}

--- a/src/main/java/io/airlift/compress/zstd/ZstdFrameDecompressorBb.java
+++ b/src/main/java/io/airlift/compress/zstd/ZstdFrameDecompressorBb.java
@@ -1,0 +1,947 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.airlift.compress.zstd;
+
+import io.airlift.compress.MalformedInputException;
+
+import java.util.Arrays;
+
+import static io.airlift.compress.zstd.BitInputStream.peekBits;
+import static io.airlift.compress.zstd.Constants.*;
+import static io.airlift.compress.zstd.UnsafeUtil.UNSAFE;
+import static io.airlift.compress.zstd.Util.*;
+import static java.lang.String.format;
+import static sun.misc.Unsafe.ARRAY_BYTE_BASE_OFFSET;
+
+class ZstdFrameDecompressorBb
+{
+    private static final int[] DEC_32_TABLE = {4, 1, 2, 1, 4, 4, 4, 4};
+    private static final int[] DEC_64_TABLE = {0, 0, 0, -1, 0, 1, 2, 3};
+
+    private static final int V07_MAGIC_NUMBER = 0xFD2FB527;
+
+    static final int MAX_WINDOW_SIZE = 1 << 23;
+
+    private static final int[] LITERALS_LENGTH_BASE = {
+            0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15,
+            16, 18, 20, 22, 24, 28, 32, 40, 48, 64, 0x80, 0x100, 0x200, 0x400, 0x800, 0x1000,
+            0x2000, 0x4000, 0x8000, 0x10000};
+
+    private static final int[] MATCH_LENGTH_BASE = {
+            3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18,
+            19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32, 33, 34,
+            35, 37, 39, 41, 43, 47, 51, 59, 67, 83, 99, 0x83, 0x103, 0x203, 0x403, 0x803,
+            0x1003, 0x2003, 0x4003, 0x8003, 0x10003};
+
+    private static final int[] OFFSET_CODES_BASE = {
+            0, 1, 1, 5, 0xD, 0x1D, 0x3D, 0x7D,
+            0xFD, 0x1FD, 0x3FD, 0x7FD, 0xFFD, 0x1FFD, 0x3FFD, 0x7FFD,
+            0xFFFD, 0x1FFFD, 0x3FFFD, 0x7FFFD, 0xFFFFD, 0x1FFFFD, 0x3FFFFD, 0x7FFFFD,
+            0xFFFFFD, 0x1FFFFFD, 0x3FFFFFD, 0x7FFFFFD, 0xFFFFFFD};
+
+    private static final FiniteStateEntropy.Table DEFAULT_LITERALS_LENGTH_TABLE = new FiniteStateEntropy.Table(
+            6,
+            new int[] {
+                    0, 16, 32, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 32, 0, 0, 0, 0, 32, 0, 0, 32, 0, 32, 0, 32, 0, 0, 32, 0, 32, 0, 32, 0, 0, 16, 32, 0, 0, 48, 16, 32, 32, 32,
+                    32, 32, 32, 32, 32, 0, 32, 32, 32, 32, 32, 32, 0, 0, 0, 0},
+            new byte[] {
+                    0, 0, 1, 3, 4, 6, 7, 9, 10, 12, 14, 16, 18, 19, 21, 22, 24, 25, 26, 27, 29, 31, 0, 1, 2, 4, 5, 7, 8, 10, 11, 13, 16, 17, 19, 20, 22, 23, 25, 25, 26, 28, 30, 0,
+                    1, 2, 3, 5, 6, 8, 9, 11, 12, 15, 17, 18, 20, 21, 23, 24, 35, 34, 33, 32},
+            new byte[] {
+                    4, 4, 5, 5, 5, 5, 5, 5, 5, 5, 6, 5, 5, 5, 5, 5, 5, 5, 5, 6, 6, 6, 4, 4, 5, 5, 5, 5, 5, 5, 5, 6, 5, 5, 5, 5, 5, 5, 4, 4, 5, 6, 6, 4, 4, 5, 5, 5, 5, 5, 5, 5, 5,
+                    6, 5, 5, 5, 5, 5, 5, 6, 6, 6, 6});
+
+    private static final FiniteStateEntropy.Table DEFAULT_OFFSET_CODES_TABLE = new FiniteStateEntropy.Table(
+            5,
+            new int[] {0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 16, 0, 0, 0, 0, 16, 0, 0, 0, 16, 0, 0, 0, 0, 0, 0, 0},
+            new byte[] {0, 6, 9, 15, 21, 3, 7, 12, 18, 23, 5, 8, 14, 20, 2, 7, 11, 17, 22, 4, 8, 13, 19, 1, 6, 10, 16, 28, 27, 26, 25, 24},
+            new byte[] {5, 4, 5, 5, 5, 5, 4, 5, 5, 5, 5, 4, 5, 5, 5, 4, 5, 5, 5, 5, 4, 5, 5, 5, 4, 5, 5, 5, 5, 5, 5, 5});
+
+    private static final FiniteStateEntropy.Table DEFAULT_MATCH_LENGTH_TABLE = new FiniteStateEntropy.Table(
+            6,
+            new int[] {
+                    0, 0, 32, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 16, 0, 32, 0, 32, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 32, 48, 16, 32, 32, 32, 32,
+                    0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0},
+            new byte[] {
+                    0, 1, 2, 3, 5, 6, 8, 10, 13, 16, 19, 22, 25, 28, 31, 33, 35, 37, 39, 41, 43, 45, 1, 2, 3, 4, 6, 7, 9, 12, 15, 18, 21, 24, 27, 30, 32, 34, 36, 38, 40, 42, 44, 1,
+                    1, 2, 4, 5, 7, 8, 11, 14, 17, 20, 23, 26, 29, 52, 51, 50, 49, 48, 47, 46},
+            new byte[] {
+                    6, 4, 5, 5, 5, 5, 5, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 4, 4, 5, 5, 5, 5, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 4, 4, 4, 5, 5, 5, 5, 6, 6, 6,
+                    6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6});
+
+    private final byte[] literals = new byte[MAX_BLOCK_SIZE + SIZE_OF_LONG]; // extra space to allow for long-at-a-time copy
+
+    // current buffer containing literals
+    private Object literalsBase;
+    private long literalsAddress;
+    private long literalsLimit;
+
+    private final int[] previousOffsets = new int[3];
+
+    private final FiniteStateEntropy.Table literalsLengthTable = new FiniteStateEntropy.Table(LITERAL_LENGTH_TABLE_LOG);
+    private final FiniteStateEntropy.Table offsetCodesTable = new FiniteStateEntropy.Table(OFFSET_TABLE_LOG);
+    private final FiniteStateEntropy.Table matchLengthTable = new FiniteStateEntropy.Table(MATCH_LENGTH_TABLE_LOG);
+
+    private FiniteStateEntropy.Table currentLiteralsLengthTable;
+    private FiniteStateEntropy.Table currentOffsetCodesTable;
+    private FiniteStateEntropy.Table currentMatchLengthTable;
+
+    private final Huffman huffman = new Huffman();
+    private final FseTableReader fse = new FseTableReader();
+
+    public int decompress(
+            final Object inputBase,
+            final long inputAddress,
+            final long inputLimit,
+            final Object outputBase,
+            final long outputAddress,
+            final long outputLimit)
+    {
+        if (outputAddress == outputLimit) {
+            return 0;
+        }
+
+        long input = inputAddress;
+        long output = outputAddress;
+
+        while (input < inputLimit) {
+            reset();
+            long outputStart = output;
+            input += verifyMagic(inputBase, input, inputLimit);
+
+            FrameHeader frameHeader = readFrameHeader(inputBase, input, inputLimit);
+            input += frameHeader.headerSize;
+
+            boolean lastBlock;
+            do {
+                verify(input + SIZE_OF_BLOCK_HEADER <= inputLimit, input, "Not enough input bytes");
+
+                // read block header
+                int header = get24BitLittleEndian(inputBase, input);
+                input += SIZE_OF_BLOCK_HEADER;
+
+                lastBlock = (header & 1) != 0;
+                int blockType = (header >>> 1) & 0b11;
+                int blockSize = (header >>> 3) & 0x1F_FFFF; // 21 bits
+
+                int decodedSize;
+                switch (blockType) {
+                    case RAW_BLOCK:
+                        verify(inputAddress + blockSize <= inputLimit, input, "Not enough input bytes");
+                        decodedSize = decodeRawBlock(inputBase, input, blockSize, outputBase, output, outputLimit);
+                        input += blockSize;
+                        break;
+                    case RLE_BLOCK:
+                        verify(inputAddress + 1 <= inputLimit, input, "Not enough input bytes");
+                        decodedSize = decodeRleBlock(blockSize, inputBase, input, outputBase, output, outputLimit);
+                        input += 1;
+                        break;
+                    case COMPRESSED_BLOCK:
+                        verify(inputAddress + blockSize <= inputLimit, input, "Not enough input bytes");
+                        decodedSize = decodeCompressedBlock(inputBase, input, blockSize, outputBase, output, outputLimit, frameHeader.windowSize, outputAddress);
+                        input += blockSize;
+                        break;
+                    default:
+                        throw fail(input, "Invalid block type");
+                }
+
+                output += decodedSize;
+            }
+            while (!lastBlock);
+
+            if (frameHeader.hasChecksum) {
+                int decodedFrameSize = (int) (output - outputStart);
+
+                long hash = XxHash64.hash(0, outputBase, outputStart, decodedFrameSize);
+
+                int checksum = UNSAFE.getInt(inputBase, input);
+                if (checksum != (int) hash) {
+                    throw new MalformedInputException(input, format("Bad checksum. Expected: %s, actual: %s", Integer.toHexString(checksum), Integer.toHexString((int) hash)));
+                }
+
+                input += SIZE_OF_INT;
+            }
+        }
+
+        return (int) (output - outputAddress);
+    }
+
+    void reset()
+    {
+        previousOffsets[0] = 1;
+        previousOffsets[1] = 4;
+        previousOffsets[2] = 8;
+
+        currentLiteralsLengthTable = null;
+        currentOffsetCodesTable = null;
+        currentMatchLengthTable = null;
+    }
+
+    static int decodeRawBlock(Object inputBase, long inputAddress, int blockSize, Object outputBase, long outputAddress, long outputLimit)
+    {
+        verify(outputAddress + blockSize <= outputLimit, inputAddress, "Output buffer too small");
+
+        UNSAFE.copyMemory(inputBase, inputAddress, outputBase, outputAddress, blockSize);
+        return blockSize;
+    }
+
+    static int decodeRleBlock(int size, Object inputBase, long inputAddress, Object outputBase, long outputAddress, long outputLimit)
+    {
+        verify(outputAddress + size <= outputLimit, inputAddress, "Output buffer too small");
+
+        long output = outputAddress;
+        long value = UNSAFE.getByte(inputBase, inputAddress) & 0xFFL;
+
+        int remaining = size;
+        if (remaining >= SIZE_OF_LONG) {
+            long packed = value
+                    | (value << 8)
+                    | (value << 16)
+                    | (value << 24)
+                    | (value << 32)
+                    | (value << 40)
+                    | (value << 48)
+                    | (value << 56);
+
+            do {
+                UNSAFE.putLong(outputBase, output, packed);
+                output += SIZE_OF_LONG;
+                remaining -= SIZE_OF_LONG;
+            }
+            while (remaining >= SIZE_OF_LONG);
+        }
+
+        for (int i = 0; i < remaining; i++) {
+            UNSAFE.putByte(outputBase, output, (byte) value);
+            output++;
+        }
+
+        return size;
+    }
+
+    int decodeCompressedBlock(
+            Object inputBase,
+            final long inputAddress,
+            int blockSize,
+            Object outputBase,
+            long outputAddress,
+            long outputLimit,
+            int windowSize,
+            long outputAbsoluteBaseAddress)
+    {
+        long inputLimit = inputAddress + blockSize;
+        long input = inputAddress;
+
+        verify(blockSize <= MAX_BLOCK_SIZE, input, "Expected match length table to be present");
+        verify(blockSize >= MIN_BLOCK_SIZE, input, "Compressed block size too small");
+
+        // decode literals
+        int literalsBlockType = UNSAFE.getByte(inputBase, input) & 0b11;
+
+        switch (literalsBlockType) {
+            case RAW_LITERALS_BLOCK: {
+                input += decodeRawLiterals(inputBase, input, inputLimit);
+                break;
+            }
+            case RLE_LITERALS_BLOCK: {
+                input += decodeRleLiterals(inputBase, input, blockSize);
+                break;
+            }
+            case TREELESS_LITERALS_BLOCK:
+                verify(huffman.isLoaded(), input, "Dictionary is corrupted");
+            case COMPRESSED_LITERALS_BLOCK: {
+                input += decodeCompressedLiterals(inputBase, input, blockSize, literalsBlockType);
+                break;
+            }
+            default:
+                throw fail(input, "Invalid literals block encoding type");
+        }
+
+        verify(windowSize <= MAX_WINDOW_SIZE, input, "Window size too large (not yet supported)");
+
+        return decompressSequences(
+                inputBase, input, inputAddress + blockSize,
+                outputBase, outputAddress, outputLimit,
+                literalsBase, literalsAddress, literalsLimit,
+                outputAbsoluteBaseAddress);
+    }
+
+    private int decompressSequences(
+            final Object inputBase, final long inputAddress, final long inputLimit,
+            final Object outputBase, final long outputAddress, final long outputLimit,
+            final Object literalsBase, final long literalsAddress, final long literalsLimit,
+            long outputAbsoluteBaseAddress)
+    {
+        final long fastOutputLimit = outputLimit - SIZE_OF_LONG;
+        final long fastMatchOutputLimit = fastOutputLimit - SIZE_OF_LONG;
+
+        long input = inputAddress;
+        long output = outputAddress;
+
+        long literalsInput = literalsAddress;
+
+        int size = (int) (inputLimit - inputAddress);
+        verify(size >= MIN_SEQUENCES_SIZE, input, "Not enough input bytes");
+
+        // decode header
+        int sequenceCount = UNSAFE.getByte(inputBase, input++) & 0xFF;
+        if (sequenceCount != 0) {
+            if (sequenceCount == 255) {
+                verify(input + SIZE_OF_SHORT <= inputLimit, input, "Not enough input bytes");
+                sequenceCount = (UNSAFE.getShort(inputBase, input) & 0xFFFF) + LONG_NUMBER_OF_SEQUENCES;
+                input += SIZE_OF_SHORT;
+            }
+            else if (sequenceCount > 127) {
+                verify(input < inputLimit, input, "Not enough input bytes");
+                sequenceCount = ((sequenceCount - 128) << 8) + (UNSAFE.getByte(inputBase, input++) & 0xFF);
+            }
+
+            verify(input + SIZE_OF_INT <= inputLimit, input, "Not enough input bytes");
+
+            byte type = UNSAFE.getByte(inputBase, input++);
+
+            int literalsLengthType = (type & 0xFF) >>> 6;
+            int offsetCodesType = (type >>> 4) & 0b11;
+            int matchLengthType = (type >>> 2) & 0b11;
+
+            input = computeLiteralsTable(literalsLengthType, inputBase, input, inputLimit);
+            input = computeOffsetsTable(offsetCodesType, inputBase, input, inputLimit);
+            input = computeMatchLengthTable(matchLengthType, inputBase, input, inputLimit);
+
+            // decompress sequences
+            BitInputStream.Initializer initializer = new BitInputStream.Initializer(inputBase, input, inputLimit);
+            initializer.initialize();
+            int bitsConsumed = initializer.getBitsConsumed();
+            long bits = initializer.getBits();
+            long currentAddress = initializer.getCurrentAddress();
+
+            FiniteStateEntropy.Table currentLiteralsLengthTable = this.currentLiteralsLengthTable;
+            FiniteStateEntropy.Table currentOffsetCodesTable = this.currentOffsetCodesTable;
+            FiniteStateEntropy.Table currentMatchLengthTable = this.currentMatchLengthTable;
+
+            int literalsLengthState = (int) peekBits(bitsConsumed, bits, currentLiteralsLengthTable.log2Size);
+            bitsConsumed += currentLiteralsLengthTable.log2Size;
+
+            int offsetCodesState = (int) peekBits(bitsConsumed, bits, currentOffsetCodesTable.log2Size);
+            bitsConsumed += currentOffsetCodesTable.log2Size;
+
+            int matchLengthState = (int) peekBits(bitsConsumed, bits, currentMatchLengthTable.log2Size);
+            bitsConsumed += currentMatchLengthTable.log2Size;
+
+            int[] previousOffsets = this.previousOffsets;
+
+            byte[] literalsLengthNumbersOfBits = currentLiteralsLengthTable.numberOfBits;
+            int[] literalsLengthNewStates = currentLiteralsLengthTable.newState;
+            byte[] literalsLengthSymbols = currentLiteralsLengthTable.symbol;
+
+            byte[] matchLengthNumbersOfBits = currentMatchLengthTable.numberOfBits;
+            int[] matchLengthNewStates = currentMatchLengthTable.newState;
+            byte[] matchLengthSymbols = currentMatchLengthTable.symbol;
+
+            byte[] offsetCodesNumbersOfBits = currentOffsetCodesTable.numberOfBits;
+            int[] offsetCodesNewStates = currentOffsetCodesTable.newState;
+            byte[] offsetCodesSymbols = currentOffsetCodesTable.symbol;
+
+            while (sequenceCount > 0) {
+                sequenceCount--;
+
+                BitInputStream.Loader loader = new BitInputStream.Loader(inputBase, input, currentAddress, bits, bitsConsumed);
+                loader.load();
+                bitsConsumed = loader.getBitsConsumed();
+                bits = loader.getBits();
+                currentAddress = loader.getCurrentAddress();
+                if (loader.isOverflow()) {
+                    verify(sequenceCount == 0, input, "Not all sequences were consumed");
+                    break;
+                }
+
+                // decode sequence
+                int literalsLengthCode = literalsLengthSymbols[literalsLengthState];
+                int matchLengthCode = matchLengthSymbols[matchLengthState];
+                int offsetCode = offsetCodesSymbols[offsetCodesState];
+
+                int literalsLengthBits = LITERALS_LENGTH_BITS[literalsLengthCode];
+                int matchLengthBits = MATCH_LENGTH_BITS[matchLengthCode];
+                int offsetBits = offsetCode;
+
+                int offset = OFFSET_CODES_BASE[offsetCode];
+                if (offsetCode > 0) {
+                    offset += peekBits(bitsConsumed, bits, offsetBits);
+                    bitsConsumed += offsetBits;
+                }
+
+                if (offsetCode <= 1) {
+                    if (literalsLengthCode == 0) {
+                        offset++;
+                    }
+
+                    if (offset != 0) {
+                        int temp;
+                        if (offset == 3) {
+                            temp = previousOffsets[0] - 1;
+                        }
+                        else {
+                            temp = previousOffsets[offset];
+                        }
+
+                        if (temp == 0) {
+                            temp = 1;
+                        }
+
+                        if (offset != 1) {
+                            previousOffsets[2] = previousOffsets[1];
+                        }
+                        previousOffsets[1] = previousOffsets[0];
+                        previousOffsets[0] = temp;
+
+                        offset = temp;
+                    }
+                    else {
+                        offset = previousOffsets[0];
+                    }
+                }
+                else {
+                    previousOffsets[2] = previousOffsets[1];
+                    previousOffsets[1] = previousOffsets[0];
+                    previousOffsets[0] = offset;
+                }
+
+                int matchLength = MATCH_LENGTH_BASE[matchLengthCode];
+                if (matchLengthCode > 31) {
+                    matchLength += peekBits(bitsConsumed, bits, matchLengthBits);
+                    bitsConsumed += matchLengthBits;
+                }
+
+                int literalsLength = LITERALS_LENGTH_BASE[literalsLengthCode];
+                if (literalsLengthCode > 15) {
+                    literalsLength += peekBits(bitsConsumed, bits, literalsLengthBits);
+                    bitsConsumed += literalsLengthBits;
+                }
+
+                int totalBits = literalsLengthBits + matchLengthBits + offsetBits;
+                if (totalBits > 64 - 7 - (LITERAL_LENGTH_TABLE_LOG + MATCH_LENGTH_TABLE_LOG + OFFSET_TABLE_LOG)) {
+                    BitInputStream.Loader loader1 = new BitInputStream.Loader(inputBase, input, currentAddress, bits, bitsConsumed);
+                    loader1.load();
+
+                    bitsConsumed = loader1.getBitsConsumed();
+                    bits = loader1.getBits();
+                    currentAddress = loader1.getCurrentAddress();
+                }
+
+                int numberOfBits;
+
+                numberOfBits = literalsLengthNumbersOfBits[literalsLengthState];
+                literalsLengthState = (int) (literalsLengthNewStates[literalsLengthState] + peekBits(bitsConsumed, bits, numberOfBits)); // <= 9 bits
+                bitsConsumed += numberOfBits;
+
+                numberOfBits = matchLengthNumbersOfBits[matchLengthState];
+                matchLengthState = (int) (matchLengthNewStates[matchLengthState] + peekBits(bitsConsumed, bits, numberOfBits)); // <= 9 bits
+                bitsConsumed += numberOfBits;
+
+                numberOfBits = offsetCodesNumbersOfBits[offsetCodesState];
+                offsetCodesState = (int) (offsetCodesNewStates[offsetCodesState] + peekBits(bitsConsumed, bits, numberOfBits)); // <= 8 bits
+                bitsConsumed += numberOfBits;
+
+                final long literalOutputLimit = output + literalsLength;
+                final long matchOutputLimit = literalOutputLimit + matchLength;
+
+                verify(matchOutputLimit <= outputLimit, input, "Output buffer too small");
+                long literalEnd = literalsInput + literalsLength;
+                verify(literalEnd <= literalsLimit, input, "Input is corrupted");
+
+                long matchAddress = literalOutputLimit - offset;
+                verify(matchAddress >= outputAbsoluteBaseAddress, input, "Input is corrupted");
+
+                if (literalOutputLimit > fastOutputLimit) {
+                    executeLastSequence(outputBase, output, literalOutputLimit, matchOutputLimit, fastOutputLimit, literalsInput, matchAddress);
+                }
+                else {
+                    // copy literals. literalOutputLimit <= fastOutputLimit, so we can copy
+                    // long at a time with over-copy
+                    output = copyLiterals(outputBase, literalsBase, output, literalsInput, literalOutputLimit);
+                    copyMatch(outputBase, fastOutputLimit, output, offset, matchOutputLimit, matchAddress, matchLength, fastMatchOutputLimit);
+                }
+                output = matchOutputLimit;
+                literalsInput = literalEnd;
+            }
+        }
+
+        // last literal segment
+        output = copyLastLiteral(outputBase, literalsBase, literalsLimit, output, literalsInput);
+
+        return (int) (output - outputAddress);
+    }
+
+    private static long copyLastLiteral(Object outputBase, Object literalsBase, long literalsLimit, long output, long literalsInput)
+    {
+        long lastLiteralsSize = literalsLimit - literalsInput;
+        UNSAFE.copyMemory(literalsBase, literalsInput, outputBase, output, lastLiteralsSize);
+        output += lastLiteralsSize;
+        return output;
+    }
+
+    private static void copyMatch(Object outputBase,
+            long fastOutputLimit,
+            long output,
+            int offset,
+            long matchOutputLimit,
+            long matchAddress,
+            int matchLength,
+            long fastMatchOutputLimit)
+    {
+        matchAddress = copyMatchHead(outputBase, output, offset, matchAddress);
+        output += SIZE_OF_LONG;
+        matchLength -= SIZE_OF_LONG; // first 8 bytes copied above
+
+        copyMatchTail(outputBase, fastOutputLimit, output, matchOutputLimit, matchAddress, matchLength, fastMatchOutputLimit);
+    }
+
+    private static void copyMatchTail(Object outputBase, long fastOutputLimit, long output, long matchOutputLimit, long matchAddress, int matchLength, long fastMatchOutputLimit)
+    {
+        // fastMatchOutputLimit is just fastOutputLimit - SIZE_OF_LONG. It needs to be passed in so that it can be computed once for the
+        // whole invocation to decompressSequences. Otherwise, we'd just compute it here.
+        // If matchOutputLimit is < fastMatchOutputLimit, we know that even after the head (8 bytes) has been copied, the output pointer
+        // will be within fastOutputLimit, so it's safe to copy blindly before checking the limit condition
+        if (matchOutputLimit < fastMatchOutputLimit) {
+            int copied = 0;
+            do {
+                UNSAFE.putLong(outputBase, output, UNSAFE.getLong(outputBase, matchAddress));
+                output += SIZE_OF_LONG;
+                matchAddress += SIZE_OF_LONG;
+                copied += SIZE_OF_LONG;
+            }
+            while (copied < matchLength);
+        }
+        else {
+            while (output < fastOutputLimit) {
+                UNSAFE.putLong(outputBase, output, UNSAFE.getLong(outputBase, matchAddress));
+                matchAddress += SIZE_OF_LONG;
+                output += SIZE_OF_LONG;
+            }
+
+            while (output < matchOutputLimit) {
+                UNSAFE.putByte(outputBase, output++, UNSAFE.getByte(outputBase, matchAddress++));
+            }
+        }
+    }
+
+    private static long copyMatchHead(Object outputBase, long output, int offset, long matchAddress)
+    {
+        // copy match
+        if (offset < 8) {
+            // 8 bytes apart so that we can copy long-at-a-time below
+            int increment32 = DEC_32_TABLE[offset];
+            int decrement64 = DEC_64_TABLE[offset];
+
+            UNSAFE.putByte(outputBase, output, UNSAFE.getByte(outputBase, matchAddress));
+            UNSAFE.putByte(outputBase, output + 1, UNSAFE.getByte(outputBase, matchAddress + 1));
+            UNSAFE.putByte(outputBase, output + 2, UNSAFE.getByte(outputBase, matchAddress + 2));
+            UNSAFE.putByte(outputBase, output + 3, UNSAFE.getByte(outputBase, matchAddress + 3));
+            matchAddress += increment32;
+
+            UNSAFE.putInt(outputBase, output + 4, UNSAFE.getInt(outputBase, matchAddress));
+            matchAddress -= decrement64;
+        }
+        else {
+            UNSAFE.putLong(outputBase, output, UNSAFE.getLong(outputBase, matchAddress));
+            matchAddress += SIZE_OF_LONG;
+        }
+        return matchAddress;
+    }
+
+    private static long copyLiterals(Object outputBase, Object literalsBase, long output, long literalsInput, long literalOutputLimit)
+    {
+        long literalInput = literalsInput;
+        do {
+            UNSAFE.putLong(outputBase, output, UNSAFE.getLong(literalsBase, literalInput));
+            output += SIZE_OF_LONG;
+            literalInput += SIZE_OF_LONG;
+        }
+        while (output < literalOutputLimit);
+        output = literalOutputLimit; // correction in case we over-copied
+        return output;
+    }
+
+    private long computeMatchLengthTable(int matchLengthType, Object inputBase, long input, long inputLimit)
+    {
+        switch (matchLengthType) {
+            case SEQUENCE_ENCODING_RLE:
+                verify(input < inputLimit, input, "Not enough input bytes");
+
+                byte value = UNSAFE.getByte(inputBase, input++);
+                verify(value <= MAX_MATCH_LENGTH_SYMBOL, input, "Value exceeds expected maximum value");
+
+                FseTableReader.initializeRleTable(matchLengthTable, value);
+                currentMatchLengthTable = matchLengthTable;
+                break;
+            case SEQUENCE_ENCODING_BASIC:
+                currentMatchLengthTable = DEFAULT_MATCH_LENGTH_TABLE;
+                break;
+            case SEQUENCE_ENCODING_REPEAT:
+                verify(currentMatchLengthTable != null, input, "Expected match length table to be present");
+                break;
+            case SEQUENCE_ENCODING_COMPRESSED:
+                input += fse.readFseTable(matchLengthTable, inputBase, input, inputLimit, MAX_MATCH_LENGTH_SYMBOL, MATCH_LENGTH_TABLE_LOG);
+                currentMatchLengthTable = matchLengthTable;
+                break;
+            default:
+                throw fail(input, "Invalid match length encoding type");
+        }
+        return input;
+    }
+
+    private long computeOffsetsTable(int offsetCodesType, Object inputBase, long input, long inputLimit)
+    {
+        switch (offsetCodesType) {
+            case SEQUENCE_ENCODING_RLE:
+                verify(input < inputLimit, input, "Not enough input bytes");
+
+                byte value = UNSAFE.getByte(inputBase, input++);
+                verify(value <= DEFAULT_MAX_OFFSET_CODE_SYMBOL, input, "Value exceeds expected maximum value");
+
+                FseTableReader.initializeRleTable(offsetCodesTable, value);
+                currentOffsetCodesTable = offsetCodesTable;
+                break;
+            case SEQUENCE_ENCODING_BASIC:
+                currentOffsetCodesTable = DEFAULT_OFFSET_CODES_TABLE;
+                break;
+            case SEQUENCE_ENCODING_REPEAT:
+                verify(currentOffsetCodesTable != null, input, "Expected match length table to be present");
+                break;
+            case SEQUENCE_ENCODING_COMPRESSED:
+                input += fse.readFseTable(offsetCodesTable, inputBase, input, inputLimit, DEFAULT_MAX_OFFSET_CODE_SYMBOL, OFFSET_TABLE_LOG);
+                currentOffsetCodesTable = offsetCodesTable;
+                break;
+            default:
+                throw fail(input, "Invalid offset code encoding type");
+        }
+        return input;
+    }
+
+    private long computeLiteralsTable(int literalsLengthType, Object inputBase, long input, long inputLimit)
+    {
+        switch (literalsLengthType) {
+            case SEQUENCE_ENCODING_RLE:
+                verify(input < inputLimit, input, "Not enough input bytes");
+
+                byte value = UNSAFE.getByte(inputBase, input++);
+                verify(value <= MAX_LITERALS_LENGTH_SYMBOL, input, "Value exceeds expected maximum value");
+
+                FseTableReader.initializeRleTable(literalsLengthTable, value);
+                currentLiteralsLengthTable = literalsLengthTable;
+                break;
+            case SEQUENCE_ENCODING_BASIC:
+                currentLiteralsLengthTable = DEFAULT_LITERALS_LENGTH_TABLE;
+                break;
+            case SEQUENCE_ENCODING_REPEAT:
+                verify(currentLiteralsLengthTable != null, input, "Expected match length table to be present");
+                break;
+            case SEQUENCE_ENCODING_COMPRESSED:
+                input += fse.readFseTable(literalsLengthTable, inputBase, input, inputLimit, MAX_LITERALS_LENGTH_SYMBOL, LITERAL_LENGTH_TABLE_LOG);
+                currentLiteralsLengthTable = literalsLengthTable;
+                break;
+            default:
+                throw fail(input, "Invalid literals length encoding type");
+        }
+        return input;
+    }
+
+    private void executeLastSequence(Object outputBase, long output, long literalOutputLimit, long matchOutputLimit, long fastOutputLimit, long literalInput, long matchAddress)
+    {
+        // copy literals
+        if (output < fastOutputLimit) {
+            // wild copy
+            do {
+                UNSAFE.putLong(outputBase, output, UNSAFE.getLong(literalsBase, literalInput));
+                output += SIZE_OF_LONG;
+                literalInput += SIZE_OF_LONG;
+            }
+            while (output < fastOutputLimit);
+
+            literalInput -= output - fastOutputLimit;
+            output = fastOutputLimit;
+        }
+
+        while (output < literalOutputLimit) {
+            UNSAFE.putByte(outputBase, output, UNSAFE.getByte(literalsBase, literalInput));
+            output++;
+            literalInput++;
+        }
+
+        // copy match
+        while (output < matchOutputLimit) {
+            UNSAFE.putByte(outputBase, output, UNSAFE.getByte(outputBase, matchAddress));
+            output++;
+            matchAddress++;
+        }
+    }
+
+    private int decodeCompressedLiterals(Object inputBase, final long inputAddress, int blockSize, int literalsBlockType)
+    {
+        long input = inputAddress;
+        verify(blockSize >= 5, input, "Not enough input bytes");
+
+        // compressed
+        int compressedSize;
+        int uncompressedSize;
+        boolean singleStream = false;
+        int headerSize;
+        int type = (UNSAFE.getByte(inputBase, input) >> 2) & 0b11;
+        switch (type) {
+            case 0:
+                singleStream = true;
+            case 1: {
+                int header = UNSAFE.getInt(inputBase, input);
+
+                headerSize = 3;
+                uncompressedSize = (header >>> 4) & mask(10);
+                compressedSize = (header >>> 14) & mask(10);
+                break;
+            }
+            case 2: {
+                int header = UNSAFE.getInt(inputBase, input);
+
+                headerSize = 4;
+                uncompressedSize = (header >>> 4) & mask(14);
+                compressedSize = (header >>> 18) & mask(14);
+                break;
+            }
+            case 3: {
+                // read 5 little-endian bytes
+                long header = UNSAFE.getByte(inputBase, input) & 0xFF |
+                        (UNSAFE.getInt(inputBase, input + 1) & 0xFFFF_FFFFL) << 8;
+
+                headerSize = 5;
+                uncompressedSize = (int) ((header >>> 4) & mask(18));
+                compressedSize = (int) ((header >>> 22) & mask(18));
+                break;
+            }
+            default:
+                throw fail(input, "Invalid literals header size type");
+        }
+
+        verify(uncompressedSize <= MAX_BLOCK_SIZE, input, "Block exceeds maximum size");
+        verify(headerSize + compressedSize <= blockSize, input, "Input is corrupted");
+
+        input += headerSize;
+
+        long inputLimit = input + compressedSize;
+        if (literalsBlockType != TREELESS_LITERALS_BLOCK) {
+            input += huffman.readTable(inputBase, input, compressedSize);
+        }
+
+        literalsBase = literals;
+        literalsAddress = ARRAY_BYTE_BASE_OFFSET;
+        literalsLimit = ARRAY_BYTE_BASE_OFFSET + uncompressedSize;
+
+        if (singleStream) {
+            huffman.decodeSingleStream(inputBase, input, inputLimit, literals, literalsAddress, literalsLimit);
+        }
+        else {
+            huffman.decode4Streams(inputBase, input, inputLimit, literals, literalsAddress, literalsLimit);
+        }
+
+        return headerSize + compressedSize;
+    }
+
+    private int decodeRleLiterals(Object inputBase, final long inputAddress, int blockSize)
+    {
+        long input = inputAddress;
+        int outputSize;
+
+        int type = (UNSAFE.getByte(inputBase, input) >> 2) & 0b11;
+        switch (type) {
+            case 0:
+            case 2:
+                outputSize = (UNSAFE.getByte(inputBase, input) & 0xFF) >>> 3;
+                input++;
+                break;
+            case 1:
+                outputSize = (UNSAFE.getShort(inputBase, input) & 0xFFFF) >>> 4;
+                input += 2;
+                break;
+            case 3:
+                // we need at least 4 bytes (3 for the header, 1 for the payload)
+                verify(blockSize >= SIZE_OF_INT, input, "Not enough input bytes");
+                outputSize = (UNSAFE.getInt(inputBase, input) & 0xFF_FFFF) >>> 4;
+                input += 3;
+                break;
+            default:
+                throw fail(input, "Invalid RLE literals header encoding type");
+        }
+
+        verify(outputSize <= MAX_BLOCK_SIZE, input, "Output exceeds maximum block size");
+
+        byte value = UNSAFE.getByte(inputBase, input++);
+        Arrays.fill(literals, 0, outputSize + SIZE_OF_LONG, value);
+
+        literalsBase = literals;
+        literalsAddress = ARRAY_BYTE_BASE_OFFSET;
+        literalsLimit = ARRAY_BYTE_BASE_OFFSET + outputSize;
+
+        return (int) (input - inputAddress);
+    }
+
+    private int decodeRawLiterals(Object inputBase, final long inputAddress, long inputLimit)
+    {
+        long input = inputAddress;
+        int type = (UNSAFE.getByte(inputBase, input) >> 2) & 0b11;
+
+        int literalSize;
+        switch (type) {
+            case 0:
+            case 2:
+                literalSize = (UNSAFE.getByte(inputBase, input) & 0xFF) >>> 3;
+                input++;
+                break;
+            case 1:
+                literalSize = (UNSAFE.getShort(inputBase, input) & 0xFFFF) >>> 4;
+                input += 2;
+                break;
+            case 3:
+                // read 3 little-endian bytes
+                int header = ((UNSAFE.getByte(inputBase, input) & 0xFF) |
+                        ((UNSAFE.getShort(inputBase, input + 1) & 0xFFFF) << 8));
+
+                literalSize = header >>> 4;
+                input += 3;
+                break;
+            default:
+                throw fail(input, "Invalid raw literals header encoding type");
+        }
+
+        verify(input + literalSize <= inputLimit, input, "Not enough input bytes");
+
+        // Set literals pointer to [input, literalSize], but only if we can copy 8 bytes at a time during sequence decoding
+        // Otherwise, copy literals into buffer that's big enough to guarantee that
+        if (literalSize > (inputLimit - input) - SIZE_OF_LONG) {
+            literalsBase = literals;
+            literalsAddress = ARRAY_BYTE_BASE_OFFSET;
+            literalsLimit = ARRAY_BYTE_BASE_OFFSET + literalSize;
+
+            UNSAFE.copyMemory(inputBase, input, literals, literalsAddress, literalSize);
+            Arrays.fill(literals, literalSize, literalSize + SIZE_OF_LONG, (byte) 0);
+        }
+        else {
+            literalsBase = inputBase;
+            literalsAddress = input;
+            literalsLimit = literalsAddress + literalSize;
+        }
+        input += literalSize;
+
+        return (int) (input - inputAddress);
+    }
+
+    static FrameHeader readFrameHeader(final Object inputBase, final long inputAddress, final long inputLimit)
+    {
+        long input = inputAddress;
+        verify(input < inputLimit, input, "Not enough input bytes");
+
+        int frameHeaderDescriptor = UNSAFE.getByte(inputBase, input++) & 0xFF;
+        boolean singleSegment = (frameHeaderDescriptor & 0b100000) != 0;
+        int dictionaryDescriptor = frameHeaderDescriptor & 0b11;
+        int contentSizeDescriptor = frameHeaderDescriptor >>> 6;
+
+        int headerSize = 1 +
+                (singleSegment ? 0 : 1) +
+                (dictionaryDescriptor == 0 ? 0 : (1 << (dictionaryDescriptor - 1))) +
+                (contentSizeDescriptor == 0 ? (singleSegment ? 1 : 0) : (1 << contentSizeDescriptor));
+
+        verify(headerSize <= inputLimit - inputAddress, input, "Not enough input bytes");
+
+        // decode window size
+        int windowSize = -1;
+        if (!singleSegment) {
+            int windowDescriptor = UNSAFE.getByte(inputBase, input++) & 0xFF;
+            int exponent = windowDescriptor >>> 3;
+            int mantissa = windowDescriptor & 0b111;
+
+            int base = 1 << (MIN_WINDOW_LOG + exponent);
+            windowSize = base + (base / 8) * mantissa;
+        }
+
+        // decode dictionary id
+        long dictionaryId = -1;
+        switch (dictionaryDescriptor) {
+            case 1:
+                dictionaryId = UNSAFE.getByte(inputBase, input) & 0xFF;
+                input += SIZE_OF_BYTE;
+                break;
+            case 2:
+                dictionaryId = UNSAFE.getShort(inputBase, input) & 0xFFFF;
+                input += SIZE_OF_SHORT;
+                break;
+            case 3:
+                dictionaryId = UNSAFE.getInt(inputBase, input) & 0xFFFF_FFFFL;
+                input += SIZE_OF_INT;
+                break;
+        }
+        verify(dictionaryId == -1, input, "Custom dictionaries not supported");
+
+        // decode content size
+        long contentSize = -1;
+        switch (contentSizeDescriptor) {
+            case 0:
+                if (singleSegment) {
+                    contentSize = UNSAFE.getByte(inputBase, input) & 0xFF;
+                    input += SIZE_OF_BYTE;
+                }
+                break;
+            case 1:
+                contentSize = UNSAFE.getShort(inputBase, input) & 0xFFFF;
+                contentSize += 256;
+                input += SIZE_OF_SHORT;
+                break;
+            case 2:
+                contentSize = UNSAFE.getInt(inputBase, input) & 0xFFFF_FFFFL;
+                input += SIZE_OF_INT;
+                break;
+            case 3:
+                contentSize = UNSAFE.getLong(inputBase, input);
+                input += SIZE_OF_LONG;
+                break;
+        }
+
+        boolean hasChecksum = (frameHeaderDescriptor & 0b100) != 0;
+
+        return new FrameHeader(
+                input - inputAddress,
+                windowSize,
+                contentSize,
+                dictionaryId,
+                hasChecksum);
+    }
+
+    public static long getDecompressedSize(final Object inputBase, final long inputAddress, final long inputLimit)
+    {
+        long input = inputAddress;
+        input += verifyMagic(inputBase, input, inputLimit);
+        return readFrameHeader(inputBase, input, inputLimit).contentSize;
+    }
+
+    static int verifyMagic(Object inputBase, long inputAddress, long inputLimit)
+    {
+        verify(inputLimit - inputAddress >= 4, inputAddress, "Not enough input bytes");
+
+        int magic = UNSAFE.getInt(inputBase, inputAddress);
+        if (magic != MAGIC_NUMBER) {
+            if (magic == V07_MAGIC_NUMBER) {
+                throw new MalformedInputException(inputAddress, "Data encoded in unsupported ZSTD v0.7 format");
+            }
+            throw new MalformedInputException(inputAddress, "Invalid magic prefix: " + Integer.toHexString(magic));
+        }
+
+        return SIZE_OF_INT;
+    }
+}

--- a/src/test/java/io/airlift/compress/AbstractTestCompressionBb.java
+++ b/src/test/java/io/airlift/compress/AbstractTestCompressionBb.java
@@ -93,7 +93,7 @@ public abstract class AbstractTestCompressionBb
     }
 
     // Tests that decompression works correctly when the decompressed data does not span the entire output buffer
-    @Test(enabled = false, dataProvider = "data")
+    @Test(dataProvider = "data")
     public void testDecompressWithOutputPadding(DataSet dataSet)
     {
         int padding = 1021;
@@ -101,18 +101,16 @@ public abstract class AbstractTestCompressionBb
         byte[] uncompressedOriginal = dataSet.getUncompressed();
         ByteBuffer compressed = prepareCompressedData(uncompressedOriginal);
 
-        byte[] uncompressed = new byte[uncompressedOriginal.length + 2 * padding]; // pre + post padding
+        ByteBuffer uncompressed = ByteBuffer.allocate(uncompressedOriginal.length + 2 * padding); // pre + post padding
+        uncompressed.position(padding).limit(uncompressedOriginal.length + padding);
 
         Decompressor decompressor = getDecompressor();
-        int uncompressedSize = decompressor.decompress(
-                compressed.array(),
-                0,
-                compressed.array().length,
-                uncompressed,
-                padding,
-                uncompressedOriginal.length + padding);
 
-        assertByteArraysEqual(uncompressed, padding, uncompressedSize, uncompressedOriginal, 0, uncompressedOriginal.length);
+        uncompressed.mark();
+        decompressor.decompress(compressed, uncompressed);
+        uncompressed.reset(); // to mark
+
+        assertByteBufferEqual(uncompressed, ByteBuffer.wrap(uncompressedOriginal));
     }
 
     @Test(enabled = false, dataProvider = "data")

--- a/src/test/java/io/airlift/compress/AbstractTestCompressionBb.java
+++ b/src/test/java/io/airlift/compress/AbstractTestCompressionBb.java
@@ -77,25 +77,19 @@ public abstract class AbstractTestCompressionBb
         testCases.addAll(dataSets);
     }
 
-    @Test(enabled = false, dataProvider = "data")
+    @Test(dataProvider = "data")
     public void testDecompress(DataSet dataSet)
-            throws Exception
     {
         byte[] uncompressedOriginal = dataSet.getUncompressed();
         ByteBuffer compressed = prepareCompressedData(uncompressedOriginal);
 
-        byte[] uncompressed = new byte[uncompressedOriginal.length];
+        ByteBuffer uncompressed = ByteBuffer.allocate(uncompressedOriginal.length).order(LITTLE_ENDIAN);
 
         Decompressor decompressor = getDecompressor();
-        int uncompressedSize = decompressor.decompress(
-                compressed.array(),
-                0,
-                compressed.array().length,
-                uncompressed,
-                0,
-                uncompressed.length);
+        decompressor.decompress(compressed, uncompressed);
+        uncompressed.flip();
 
-        assertByteArraysEqual(uncompressed, 0, uncompressedSize, uncompressedOriginal, 0, uncompressedOriginal.length);
+        assertByteBufferEqual(uncompressed, ByteBuffer.wrap(uncompressedOriginal));
     }
 
     // Tests that decompression works correctly when the decompressed data does not span the entire output buffer

--- a/src/test/java/io/airlift/compress/AbstractTestCompressionBb.java
+++ b/src/test/java/io/airlift/compress/AbstractTestCompressionBb.java
@@ -180,7 +180,7 @@ public abstract class AbstractTestCompressionBb
                 .hasMessageMatching("All input was not consumed|attempt to write.* outside of destination buffer.*|Malformed input.*|Uncompressed length 1024 must be less than 1|Output buffer too small.*");
     }
 
-    @Test(enabled = false, dataProvider = "data")
+    @Test(dataProvider = "data")
     public void testDecompressByteBufferHeapToHeap(DataSet dataSet)
             throws Exception
     {
@@ -199,7 +199,7 @@ public abstract class AbstractTestCompressionBb
         assertByteBufferEqual(ByteBuffer.wrap(uncompressedOriginal), uncompressed);
     }
 
-    @Test(enabled = false, dataProvider = "data")
+    @Test(dataProvider = "data")
     public void testDecompressByteBufferHeapToDirect(DataSet dataSet)
             throws Exception
     {
@@ -218,7 +218,7 @@ public abstract class AbstractTestCompressionBb
         assertByteBufferEqual(ByteBuffer.wrap(uncompressedOriginal), uncompressed);
     }
 
-    @Test(enabled = false, dataProvider = "data")
+    @Test(dataProvider = "data")
     public void testDecompressByteBufferDirectToHeap(DataSet dataSet)
             throws Exception
     {
@@ -237,7 +237,7 @@ public abstract class AbstractTestCompressionBb
         assertByteBufferEqual(ByteBuffer.wrap(uncompressedOriginal), uncompressed);
     }
 
-    @Test(enabled = false, dataProvider = "data")
+    @Test(dataProvider = "data")
     public void testDecompressByteBufferDirectToDirect(DataSet dataSet)
             throws Exception
     {

--- a/src/test/java/io/airlift/compress/AbstractTestCompressionBb.java
+++ b/src/test/java/io/airlift/compress/AbstractTestCompressionBb.java
@@ -578,7 +578,7 @@ public abstract class AbstractTestCompressionBb
         assertEquals(leftLength, rightLength, String.format("Array lengths differ: %s vs %s", leftLength, rightLength));
     }
 
-    private static void assertByteBufferEqual(ByteBuffer left, ByteBuffer right)
+    public static void assertByteBufferEqual(ByteBuffer left, ByteBuffer right)
     {
         Buffer leftBuffer = left;
         Buffer rightBuffer = right;

--- a/src/test/java/io/airlift/compress/AbstractTestCompressionBb.java
+++ b/src/test/java/io/airlift/compress/AbstractTestCompressionBb.java
@@ -1,0 +1,623 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.airlift.compress;
+
+import com.google.common.primitives.Bytes;
+import io.airlift.compress.benchmark.DataSet;
+import org.testng.SkipException;
+import org.testng.annotations.DataProvider;
+import org.testng.annotations.Guice;
+import org.testng.annotations.Test;
+
+import javax.inject.Inject;
+import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.nio.Buffer;
+import java.nio.ByteBuffer;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Random;
+import java.util.concurrent.ThreadLocalRandom;
+
+import static com.google.common.base.Preconditions.checkPositionIndexes;
+import static java.lang.System.arraycopy;
+import static java.nio.charset.StandardCharsets.UTF_8;
+import static org.assertj.core.api.Assertions.*;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.fail;
+
+@Guice(modules = TestingModule.class)
+public abstract class AbstractTestCompressionBb
+{
+    private List<DataSet> testCases;
+
+    protected abstract Compressor getCompressor();
+
+    protected abstract Decompressor getDecompressor();
+
+    protected abstract Compressor getVerifyCompressor();
+
+    protected abstract Decompressor getVerifyDecompressor();
+
+    protected boolean isByteBufferSupported()
+    {
+        return true;
+    }
+
+    @Inject
+    public void setup(List<DataSet> dataSets)
+    {
+        testCases = new ArrayList<>();
+
+        testCases.add(new DataSet("nothing", new byte[0]));
+        testCases.add(new DataSet("short literal", "hello world!".getBytes(UTF_8)));
+        testCases.add(new DataSet("small copy", "XXXXabcdabcdABCDABCDwxyzwzyz123".getBytes(UTF_8)));
+        testCases.add(new DataSet("long copy", "XXXXabcdefgh abcdefgh abcdefgh abcdefgh abcdefgh abcdefgh ABC".getBytes(UTF_8)));
+
+        byte[] data = new byte[256];
+        for (int i = 0; i < data.length; i++) {
+            data[i] = (byte) i;
+        }
+        testCases.add(new DataSet("long literal", data));
+
+        testCases.addAll(dataSets);
+    }
+
+    @Test(enabled = false, dataProvider = "data")
+    public void testDecompress(DataSet dataSet)
+            throws Exception
+    {
+        byte[] uncompressedOriginal = dataSet.getUncompressed();
+        byte[] compressed = prepareCompressedData(uncompressedOriginal);
+
+        byte[] uncompressed = new byte[uncompressedOriginal.length];
+
+        Decompressor decompressor = getDecompressor();
+        int uncompressedSize = decompressor.decompress(
+                compressed,
+                0,
+                compressed.length,
+                uncompressed,
+                0,
+                uncompressed.length);
+
+        assertByteArraysEqual(uncompressed, 0, uncompressedSize, uncompressedOriginal, 0, uncompressedOriginal.length);
+    }
+
+    // Tests that decompression works correctly when the decompressed data does not span the entire output buffer
+    @Test(enabled = false, dataProvider = "data")
+    public void testDecompressWithOutputPadding(DataSet dataSet)
+    {
+        int padding = 1021;
+
+        byte[] uncompressedOriginal = dataSet.getUncompressed();
+        byte[] compressed = prepareCompressedData(uncompressedOriginal);
+
+        byte[] uncompressed = new byte[uncompressedOriginal.length + 2 * padding]; // pre + post padding
+
+        Decompressor decompressor = getDecompressor();
+        int uncompressedSize = decompressor.decompress(
+                compressed,
+                0,
+                compressed.length,
+                uncompressed,
+                padding,
+                uncompressedOriginal.length + padding);
+
+        assertByteArraysEqual(uncompressed, padding, uncompressedSize, uncompressedOriginal, 0, uncompressedOriginal.length);
+    }
+
+    @Test(enabled = false, dataProvider = "data")
+    public void testDecompressionBufferOverrun(DataSet dataSet)
+    {
+        byte[] uncompressedOriginal = dataSet.getUncompressed();
+        byte[] compressed = prepareCompressedData(uncompressedOriginal);
+
+        // add padding with random bytes that we can verify later
+        byte[] padding = new byte[100];
+        ThreadLocalRandom.current().nextBytes(padding);
+
+        byte[] uncompressed = Bytes.concat(new byte[uncompressedOriginal.length], padding);
+
+        Decompressor decompressor = getDecompressor();
+        int uncompressedSize = decompressor.decompress(
+                compressed,
+                0,
+                compressed.length,
+                uncompressed,
+                0,
+                uncompressedOriginal.length);
+
+        assertByteArraysEqual(uncompressed, 0, uncompressedSize, uncompressedOriginal, 0, uncompressedOriginal.length);
+
+        // verify padding is intact
+        assertByteArraysEqual(padding, 0, padding.length, uncompressed, uncompressed.length - padding.length, padding.length);
+    }
+
+    @Test(enabled = false)
+    public void testDecompressInputBoundsChecks()
+    {
+        byte[] data = new byte[1024];
+        new Random(1234).nextBytes(data);
+        Compressor compressor = getCompressor();
+        byte[] compressed = new byte[compressor.maxCompressedLength(data.length)];
+        int compressedLength = compressor.compress(data, 0, data.length, compressed, 0, compressed.length);
+
+        Decompressor decompressor = getDecompressor();
+        Throwable throwable;
+
+        // null input buffer
+        assertThatThrownBy(() -> decompressor.decompress(null, 0, compressedLength, data, 0, data.length))
+                .isInstanceOf(NullPointerException.class);
+
+        // mis-declared buffer size
+        byte[] compressedChoppedOff = Arrays.copyOf(compressed, compressedLength - 1);
+        throwable = catchThrowable(() -> decompressor.decompress(compressedChoppedOff, 0, compressedLength, data, 0, data.length));
+        if (throwable instanceof UncheckedIOException) {
+            // OK
+        }
+        else {
+            assertThat(throwable)
+                    .hasMessageMatching(".*must not be greater than size.*|Invalid offset or length.*");
+        }
+
+        // overrun because of offset
+        byte[] compressedWithPadding = new byte[10 + compressedLength - 1];
+        arraycopy(compressed, 0, compressedWithPadding, 10, compressedLength - 1);
+
+        throwable = catchThrowable(() -> decompressor.decompress(compressedWithPadding, 10, compressedLength, data, 0, data.length));
+        if (throwable instanceof UncheckedIOException) {
+            // OK
+        }
+        else {
+            assertThat(throwable)
+                    .hasMessageMatching(".*must not be greater than size.*|Invalid offset or length.*");
+        }
+    }
+
+    @Test(enabled = false)
+    public void testDecompressOutputBoundsChecks()
+    {
+        byte[] data = new byte[1024];
+        new Random(1234).nextBytes(data);
+        Compressor compressor = getCompressor();
+        byte[] compressed = new byte[compressor.maxCompressedLength(data.length)];
+        int compressedLength = compressor.compress(data, 0, data.length, compressed, 0, compressed.length);
+        byte[] input = Arrays.copyOf(compressed, compressedLength);
+
+        Decompressor decompressor = getDecompressor();
+        Throwable throwable;
+
+        // null output buffer
+        assertThatThrownBy(() -> decompressor.decompress(input, 0, input.length, null, 0, data.length))
+                .isInstanceOf(NullPointerException.class);
+
+        // small buffer
+        assertThatThrownBy(() -> decompressor.decompress(input, 0, input.length, new byte[1], 0, 1))
+                .hasMessageMatching("All input was not consumed|attempt to write.* outside of destination buffer.*|Malformed input.*|Uncompressed length 1024 must be less than 1|Output buffer too small.*");
+
+        // mis-declared buffer size
+        throwable = catchThrowable(() -> decompressor.decompress(input, 0, input.length, new byte[1], 0, data.length));
+        if (throwable instanceof IndexOutOfBoundsException) {
+            // OK
+        }
+        else {
+            assertThat(throwable)
+                    .hasMessageMatching(".*must not be greater than size.*|Invalid offset or length.*");
+        }
+
+        // mis-declared buffer size with greater buffer
+        throwable = catchThrowable(() -> decompressor.decompress(input, 0, input.length, new byte[data.length - 1], 0, data.length));
+        if (throwable instanceof IndexOutOfBoundsException) {
+            // OK
+        }
+        else {
+            assertThat(throwable)
+                    .hasMessageMatching(".*must not be greater than size.*|Invalid offset or length.*");
+        }
+    }
+
+    @Test(enabled = false, dataProvider = "data")
+    public void testDecompressByteBufferHeapToHeap(DataSet dataSet)
+            throws Exception
+    {
+        if (!isByteBufferSupported()) {
+            throw new SkipException("ByteBuffer not supported");
+        }
+
+        byte[] uncompressedOriginal = dataSet.getUncompressed();
+
+        ByteBuffer compressed = ByteBuffer.wrap(prepareCompressedData(uncompressedOriginal));
+        ByteBuffer uncompressed = ByteBuffer.allocate(uncompressedOriginal.length);
+
+        getDecompressor().decompress(compressed, uncompressed);
+        ((Buffer) uncompressed).flip();
+
+        assertByteBufferEqual(ByteBuffer.wrap(uncompressedOriginal), uncompressed);
+    }
+
+    @Test(enabled = false, dataProvider = "data")
+    public void testDecompressByteBufferHeapToDirect(DataSet dataSet)
+            throws Exception
+    {
+        if (!isByteBufferSupported()) {
+            throw new SkipException("ByteBuffer not supported");
+        }
+
+        byte[] uncompressedOriginal = dataSet.getUncompressed();
+
+        ByteBuffer compressed = ByteBuffer.wrap(prepareCompressedData(uncompressedOriginal));
+        ByteBuffer uncompressed = ByteBuffer.allocateDirect(uncompressedOriginal.length);
+
+        getDecompressor().decompress(compressed, uncompressed);
+        ((Buffer) uncompressed).flip();
+
+        assertByteBufferEqual(ByteBuffer.wrap(uncompressedOriginal), uncompressed);
+    }
+
+    @Test(enabled = false, dataProvider = "data")
+    public void testDecompressByteBufferDirectToHeap(DataSet dataSet)
+            throws Exception
+    {
+        if (!isByteBufferSupported()) {
+            throw new SkipException("ByteBuffer not supported");
+        }
+
+        byte[] uncompressedOriginal = dataSet.getUncompressed();
+
+        ByteBuffer compressed = toDirectBuffer(prepareCompressedData(uncompressedOriginal));
+        ByteBuffer uncompressed = ByteBuffer.allocate(uncompressedOriginal.length);
+
+        getDecompressor().decompress(compressed, uncompressed);
+        ((Buffer) uncompressed).flip();
+
+        assertByteBufferEqual(ByteBuffer.wrap(uncompressedOriginal), uncompressed);
+    }
+
+    @Test(enabled = false, dataProvider = "data")
+    public void testDecompressByteBufferDirectToDirect(DataSet dataSet)
+            throws Exception
+    {
+        if (!isByteBufferSupported()) {
+            throw new SkipException("ByteBuffer not supported");
+        }
+
+        byte[] uncompressedOriginal = dataSet.getUncompressed();
+
+        ByteBuffer compressed = toDirectBuffer(prepareCompressedData(uncompressedOriginal));
+        ByteBuffer uncompressed = ByteBuffer.allocateDirect(uncompressedOriginal.length);
+
+        getDecompressor().decompress(compressed, uncompressed);
+        ((Buffer) uncompressed).flip();
+
+        assertByteBufferEqual(ByteBuffer.wrap(uncompressedOriginal), uncompressed);
+    }
+
+    @Test(enabled = false, dataProvider = "data")
+    public void testCompress(DataSet testCase)
+            throws Exception
+    {
+        Compressor compressor = getCompressor();
+
+        byte[] originalUncompressed = testCase.getUncompressed();
+        byte[] compressed = new byte[compressor.maxCompressedLength(originalUncompressed.length)];
+
+        // attempt to compress slightly different data to ensure the compressor doesn't keep state
+        // between calls that may affect results
+        if (originalUncompressed.length > 1) {
+            byte[] output = new byte[compressor.maxCompressedLength(originalUncompressed.length - 1)];
+            compressor.compress(originalUncompressed, 1, originalUncompressed.length - 1, output, 0, output.length);
+        }
+
+        int compressedLength = compressor.compress(
+                originalUncompressed,
+                0,
+                originalUncompressed.length,
+                compressed,
+                0,
+                compressed.length);
+
+        verifyCompressedData(originalUncompressed, compressed, compressedLength);
+    }
+
+    @Test(enabled = false)
+    public void testCompressInputBoundsChecks()
+    {
+        Compressor compressor = getCompressor();
+        int declaredInputLength = 1024;
+        int maxCompressedLength = compressor.maxCompressedLength(1024);
+        byte[] output = new byte[maxCompressedLength];
+        Throwable throwable;
+
+        // null input buffer
+        assertThatThrownBy(() -> compressor.compress(null, 0, declaredInputLength, output, 0, output.length))
+                .isInstanceOf(NullPointerException.class);
+
+        // mis-declared buffer size
+        throwable = catchThrowable(() -> compressor.compress(new byte[1], 0, declaredInputLength, output, 0, output.length));
+        if (throwable instanceof IndexOutOfBoundsException) {
+            // OK
+        }
+        else {
+            assertThat(throwable)
+                    .hasMessageMatching(".*must not be greater than size.*|Invalid offset or length.*");
+        }
+
+        // max too small
+        throwable = catchThrowable(() -> compressor.compress(new byte[declaredInputLength - 1], 0, declaredInputLength, output, 0, output.length));
+        if (throwable instanceof IndexOutOfBoundsException) {
+            // OK
+        }
+        else {
+            assertThat(throwable)
+                    .hasMessageMatching(".*must not be greater than size.*|Invalid offset or length.*");
+        }
+
+        // overrun because of offset
+        throwable = catchThrowable(() -> compressor.compress(new byte[declaredInputLength + 10], 11, declaredInputLength, output, 0, output.length));
+        if (throwable instanceof IndexOutOfBoundsException) {
+            // OK
+        }
+        else {
+            assertThat(throwable)
+                    .hasMessageMatching(".*must not be greater than size.*|Invalid offset or length.*");
+        }
+    }
+
+    @Test(enabled = false)
+    public void testCompressOutputBoundsChecks()
+    {
+        Compressor compressor = getCompressor();
+        int minCompressionOverhead = compressor.maxCompressedLength(0);
+        byte[] input = new byte[minCompressionOverhead * 4 + 1024];
+        new Random(1234).nextBytes(input);
+        int maxCompressedLength = compressor.maxCompressedLength(input.length);
+        Throwable throwable;
+
+        // null output buffer
+        assertThatThrownBy(() -> compressor.compress(input, 0, input.length, null, 0, maxCompressedLength))
+                .isInstanceOf(NullPointerException.class);
+
+        // small buffer
+        assertThatThrownBy(() -> compressor.compress(input, 0, input.length, new byte[1], 0, 1))
+                .hasMessageMatching(".*must not be greater than size.*|Invalid offset or length.*|Max output length must be larger than .*|Output buffer must be at least.*|Output buffer too small");
+
+        // mis-declared buffer size
+        throwable = catchThrowable(() -> compressor.compress(input, 0, input.length, new byte[1], 0, maxCompressedLength));
+        if (throwable instanceof ArrayIndexOutOfBoundsException) {
+            // OK
+        }
+        else {
+            assertThat(throwable)
+                    .hasMessageMatching(".*must not be greater than size.*|Invalid offset or length.*");
+        }
+
+        // mis-declared buffer size with buffer large enough to hold compression frame header (if any)
+        throwable = catchThrowable(() -> compressor.compress(input, 0, input.length, new byte[minCompressionOverhead * 2], 0, maxCompressedLength));
+        if (throwable instanceof ArrayIndexOutOfBoundsException) {
+            // OK
+        }
+        else {
+            assertThat(throwable)
+                    .hasMessageMatching(".*must not be greater than size.*|Invalid offset or length.*");
+        }
+    }
+
+    @Test(enabled = false, dataProvider = "data")
+    public void testCompressByteBufferHeapToHeap(DataSet dataSet)
+            throws Exception
+    {
+        if (!isByteBufferSupported()) {
+            throw new SkipException("ByteBuffer not supported");
+        }
+
+        byte[] uncompressedOriginal = dataSet.getUncompressed();
+
+        Compressor compressor = getCompressor();
+
+        verifyCompressByteBuffer(
+                compressor,
+                ByteBuffer.wrap(uncompressedOriginal),
+                ByteBuffer.allocate(compressor.maxCompressedLength(uncompressedOriginal.length)));
+    }
+
+    @Test(enabled = false, dataProvider = "data")
+    public void testCompressByteBufferHeapToDirect(DataSet dataSet)
+            throws Exception
+    {
+        if (!isByteBufferSupported()) {
+            throw new SkipException("ByteBuffer not supported");
+        }
+
+        byte[] uncompressedOriginal = dataSet.getUncompressed();
+
+        Compressor compressor = getCompressor();
+
+        verifyCompressByteBuffer(
+                compressor,
+                ByteBuffer.wrap(uncompressedOriginal),
+                ByteBuffer.allocateDirect(compressor.maxCompressedLength(uncompressedOriginal.length)));
+    }
+
+    @Test(enabled = false, dataProvider = "data")
+    public void testCompressByteBufferDirectToHeap(DataSet dataSet)
+            throws Exception
+    {
+        if (!isByteBufferSupported()) {
+            throw new SkipException("ByteBuffer not supported");
+        }
+
+        byte[] uncompressedOriginal = dataSet.getUncompressed();
+
+        Compressor compressor = getCompressor();
+
+        verifyCompressByteBuffer(
+                compressor,
+                toDirectBuffer(uncompressedOriginal),
+                ByteBuffer.allocate(compressor.maxCompressedLength(uncompressedOriginal.length)));
+    }
+
+    @Test(enabled = false, dataProvider = "data")
+    public void testCompressByteBufferDirectToDirect(DataSet dataSet)
+            throws Exception
+    {
+        if (!isByteBufferSupported()) {
+            throw new SkipException("ByteBuffer not supported");
+        }
+
+        byte[] uncompressedOriginal = dataSet.getUncompressed();
+
+        Compressor compressor = getCompressor();
+
+        verifyCompressByteBuffer(
+                compressor,
+                toDirectBuffer(uncompressedOriginal),
+                ByteBuffer.allocateDirect(compressor.maxCompressedLength(uncompressedOriginal.length)));
+    }
+
+    private void verifyCompressByteBuffer(Compressor compressor, ByteBuffer expected, ByteBuffer compressed)
+    {
+        // attempt to compress slightly different data to ensure the compressor doesn't keep state
+        // between calls that may affect results
+        if (expected.remaining() > 1) {
+            ByteBuffer duplicate = expected.duplicate();
+            duplicate.get(); // skip one byte
+            compressor.compress(duplicate, ByteBuffer.allocate(((Buffer) compressed).remaining()));
+        }
+
+        compressor.compress(expected.duplicate(), compressed);
+        ((Buffer) compressed).flip();
+
+        ByteBuffer uncompressed = ByteBuffer.allocate(((Buffer) expected).remaining());
+
+        // TODO: validate with "control" decompressor
+        getDecompressor().decompress(compressed, uncompressed);
+        ((Buffer) uncompressed).flip();
+
+        assertByteBufferEqual(expected.duplicate(), uncompressed);
+    }
+
+    private void verifyCompressedData(byte[] originalUncompressed, byte[] compressed, int compressedLength)
+    {
+        byte[] uncompressed = new byte[originalUncompressed.length];
+        int uncompressedSize = getVerifyDecompressor().decompress(compressed, 0, compressedLength, uncompressed, 0, uncompressed.length);
+
+        assertByteArraysEqual(uncompressed, 0, uncompressedSize, originalUncompressed, 0, originalUncompressed.length);
+    }
+
+    @Test(enabled = false)
+    public void testRoundTripSmallLiteral()
+            throws Exception
+    {
+        byte[] data = new byte[256];
+        for (int i = 0; i < data.length; i++) {
+            data[i] = (byte) i;
+        }
+
+        Compressor compressor = getCompressor();
+        byte[] compressed = new byte[compressor.maxCompressedLength(data.length)];
+        byte[] uncompressed = new byte[data.length];
+
+        for (int i = 1; i < data.length; i++) {
+            try {
+                int written = compressor.compress(
+                        data,
+                        0,
+                        i,
+                        compressed,
+                        0,
+                        compressed.length);
+
+                int decompressedSize = getDecompressor().decompress(compressed, 0, written, uncompressed, 0, uncompressed.length);
+
+                assertByteArraysEqual(data, 0, i, uncompressed, 0, decompressedSize);
+                assertEquals(decompressedSize, i);
+            }
+            catch (MalformedInputException e) {
+                throw new RuntimeException("Failed with " + i + " bytes of input", e);
+            }
+        }
+    }
+
+    @DataProvider(name = "data")
+    public Object[][] getTestCases()
+            throws IOException
+    {
+        Object[][] result = new Object[testCases.size()][];
+
+        for (int i = 0; i < testCases.size(); i++) {
+            result[i] = new Object[] {testCases.get(i)};
+        }
+
+        return result;
+    }
+
+    public static void assertByteArraysEqual(byte[] left, int leftOffset, int leftLength, byte[] right, int rightOffset, int rightLength)
+    {
+        checkPositionIndexes(leftOffset, leftOffset + leftLength, left.length);
+        checkPositionIndexes(rightOffset, rightOffset + rightLength, right.length);
+
+        for (int i = 0; i < Math.min(leftLength, rightLength); i++) {
+            if (left[leftOffset + i] != right[rightOffset + i]) {
+                fail(String.format("Byte arrays differ at position %s: 0x%02X vs 0x%02X", i, left[leftOffset + i], right[rightOffset + i]));
+            }
+        }
+
+        assertEquals(leftLength, rightLength, String.format("Array lengths differ: %s vs %s", leftLength, rightLength));
+    }
+
+    private static void assertByteBufferEqual(ByteBuffer left, ByteBuffer right)
+    {
+        Buffer leftBuffer = left;
+        Buffer rightBuffer = right;
+
+        int leftPosition = leftBuffer.position();
+        int rightPosition = rightBuffer.position();
+        for (int i = 0; i < Math.min(leftBuffer.remaining(), rightBuffer.remaining()); i++) {
+            if (left.get(leftPosition + i) != right.get(rightPosition + i)) {
+                fail(String.format("Byte buffers differ at position %s: 0x%02X vs 0x%02X", i, left.get(leftPosition + i), right.get(rightPosition + i)));
+            }
+        }
+
+        assertEquals(leftBuffer.remaining(), rightBuffer.remaining(), String.format("Buffer lengths differ: %s vs %s", leftBuffer.remaining(), leftBuffer.remaining()));
+    }
+
+    private static ByteBuffer toDirectBuffer(byte[] data)
+    {
+        ByteBuffer direct = ByteBuffer.allocateDirect(data.length);
+        direct.put(data);
+
+        ((Buffer) direct).flip();
+
+        return direct;
+    }
+
+    private byte[] prepareCompressedData(byte[] uncompressed)
+    {
+        Compressor compressor = getVerifyCompressor();
+
+        byte[] compressed = new byte[compressor.maxCompressedLength(uncompressed.length)];
+
+        int compressedLength = compressor.compress(
+                uncompressed,
+                0,
+                uncompressed.length,
+                compressed,
+                0,
+                compressed.length);
+
+        return Arrays.copyOf(compressed, compressedLength);
+    }
+}

--- a/src/test/java/io/airlift/compress/Util.java
+++ b/src/test/java/io/airlift/compress/Util.java
@@ -15,10 +15,12 @@ package io.airlift.compress;
 
 import java.io.IOException;
 import java.net.URL;
+import java.nio.ByteBuffer;
 import java.nio.file.Files;
 import java.nio.file.Path;
 
 import static java.lang.String.format;
+import static java.nio.ByteOrder.LITTLE_ENDIAN;
 import static java.util.Objects.requireNonNull;
 
 public final class Util
@@ -59,5 +61,13 @@ public final class Util
     {
         Path path = getResourceAsPath(resourcePath);
         return Files.readAllBytes(path);
+    }
+
+    /**
+     * Reads data from classloader resources as a {@link ByteBuffer}.
+     */
+    public static ByteBuffer readResourceBb(String filePath) throws IOException
+    {
+        return ByteBuffer.wrap(readResource(filePath)).order(LITTLE_ENDIAN);
     }
 }

--- a/src/test/java/io/airlift/compress/zstd/TestZstd.java
+++ b/src/test/java/io/airlift/compress/zstd/TestZstd.java
@@ -178,8 +178,6 @@ public class TestZstd
 
         int compressedLength = compressor.compress(originalUncompressed, 0, originalUncompressed.length, compressed, 0, compressed.length);
 
-        assertByteArraysEqual(compressed, 0, compressed.length, compressed, 0, compressed.length);
-
         assertEquals(ZstdDecompressor.getDecompressedSize(compressed, 0, compressedLength), originalUncompressed.length);
 
         int padding = 10;

--- a/src/test/java/io/airlift/compress/zstd/TestZstdBb.java
+++ b/src/test/java/io/airlift/compress/zstd/TestZstdBb.java
@@ -24,6 +24,7 @@ import java.io.IOException;
 import java.io.UncheckedIOException;
 import java.nio.ByteBuffer;
 import java.util.Arrays;
+import java.util.List;
 
 import static io.airlift.compress.Util.readResource;
 import static io.airlift.compress.Util.readResourceBb;
@@ -88,14 +89,14 @@ public class TestZstdBb
         assertByteArraysEqual(uncompressed, 0, uncompressed.length, output, 0, output.length);
     }
 
-    @Test(enabled = false)
+    @Test
     public void testInvalidSequenceOffset()
             throws IOException
     {
-        byte[] compressed = readResource("data/zstd/offset-before-start.zst");
-        byte[] output = new byte[compressed.length * 10];
+        ByteBuffer compressed = readResourceBb("data/zstd/offset-before-start.zst");
+        ByteBuffer output = ByteBuffer.allocate(compressed.remaining() * 10).order(LITTLE_ENDIAN);
 
-        assertThatThrownBy(() -> getDecompressor().decompress(compressed, 0, compressed.length, output, 0, output.length))
+        assertThatThrownBy(() -> getDecompressor().decompress(compressed, output))
                 .isInstanceOf(MalformedInputException.class)
                 .hasMessageStartingWith("Input is corrupted: offset=894");
     }

--- a/src/test/java/io/airlift/compress/zstd/TestZstdBb.java
+++ b/src/test/java/io/airlift/compress/zstd/TestZstdBb.java
@@ -76,17 +76,18 @@ public class TestZstdBb
         assertByteArraysEqual(uncompressed, 0, uncompressed.length, output, padding, decompressedSize);
     }
 
-    @Test(enabled = false)
+    @Test
     public void testConcatenatedFrames()
             throws IOException
     {
-        byte[] compressed = readResource("data/zstd/multiple-frames.zst");
-        byte[] uncompressed = readResource("data/zstd/multiple-frames");
+        ByteBuffer compressed = readResourceBb("data/zstd/multiple-frames.zst");
+        ByteBuffer uncompressed = readResourceBb("data/zstd/multiple-frames");
 
-        byte[] output = new byte[uncompressed.length];
-        getDecompressor().decompress(compressed, 0, compressed.length, output, 0, output.length);
+        ByteBuffer output = ByteBuffer.allocate(uncompressed.remaining()).order(LITTLE_ENDIAN);
+        getDecompressor().decompress(compressed, output);
 
-        assertByteArraysEqual(uncompressed, 0, uncompressed.length, output, 0, output.length);
+        output.rewind();
+        assertByteBufferEqual(uncompressed, output);
     }
 
     @Test

--- a/src/test/java/io/airlift/compress/zstd/TestZstdBb.java
+++ b/src/test/java/io/airlift/compress/zstd/TestZstdBb.java
@@ -1,0 +1,211 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.airlift.compress.zstd;
+
+import io.airlift.compress.*;
+import io.airlift.compress.benchmark.DataSet;
+import io.airlift.compress.thirdparty.ZstdJniCompressor;
+import io.airlift.compress.thirdparty.ZstdJniDecompressor;
+import io.trino.hadoop.$internal.com.microsoft.azure.storage.table.Ignore;
+import org.testng.annotations.Test;
+
+import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.util.Arrays;
+
+import static io.airlift.compress.Util.readResource;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.testng.Assert.assertEquals;
+
+public class TestZstdBb
+        extends AbstractTestCompressionBb
+{
+    @Override
+    protected Compressor getCompressor()
+    {
+        return new ZstdCompressor();
+    }
+
+    @Override
+    protected Decompressor getDecompressor()
+    {
+        return new ZstdDecompressor();
+    }
+
+    @Override
+    protected Compressor getVerifyCompressor()
+    {
+        return new ZstdJniCompressor(3);
+    }
+
+    @Override
+    protected Decompressor getVerifyDecompressor()
+    {
+        return new ZstdJniDecompressor();
+    }
+
+    // Ideally, this should be covered by super.testDecompressWithOutputPadding(...), but the data written by the native
+    // compressor doesn't include checksums, so it's not a comprehensive test. The dataset for this test has a checksum.
+    @Test(enabled = false)
+    public void testDecompressWithOutputPaddingAndChecksum()
+            throws IOException
+    {
+        int padding = 1021;
+
+        byte[] compressed = readResource("data/zstd/with-checksum.zst");
+        byte[] uncompressed = readResource("data/zstd/with-checksum");
+
+        byte[] output = new byte[uncompressed.length + padding * 2]; // pre + post padding
+        int decompressedSize = getDecompressor().decompress(compressed, 0, compressed.length, output, padding, output.length - padding);
+
+        assertByteArraysEqual(uncompressed, 0, uncompressed.length, output, padding, decompressedSize);
+    }
+
+    @Test(enabled = false)
+    public void testConcatenatedFrames()
+            throws IOException
+    {
+        byte[] compressed = readResource("data/zstd/multiple-frames.zst");
+        byte[] uncompressed = readResource("data/zstd/multiple-frames");
+
+        byte[] output = new byte[uncompressed.length];
+        getDecompressor().decompress(compressed, 0, compressed.length, output, 0, output.length);
+
+        assertByteArraysEqual(uncompressed, 0, uncompressed.length, output, 0, output.length);
+    }
+
+    @Test(enabled = false)
+    public void testInvalidSequenceOffset()
+            throws IOException
+    {
+        byte[] compressed = readResource("data/zstd/offset-before-start.zst");
+        byte[] output = new byte[compressed.length * 10];
+
+        assertThatThrownBy(() -> getDecompressor().decompress(compressed, 0, compressed.length, output, 0, output.length))
+                .isInstanceOf(MalformedInputException.class)
+                .hasMessageStartingWith("Input is corrupted: offset=894");
+    }
+
+    @Test(enabled = false)
+    public void testSmallLiteralsAfterIncompressibleLiterals()
+            throws IOException
+    {
+        // Ensure the compressor doesn't try to reuse a huffman table that was created speculatively for a previous block
+        // which ended up emitting raw literals due to insufficient gain
+        Compressor compressor = getCompressor();
+
+        byte[] original = readResource("data/zstd/small-literals-after-incompressible-literals");
+        int maxCompressLength = compressor.maxCompressedLength(original.length);
+
+        byte[] compressed = new byte[maxCompressLength];
+        int compressedSize = compressor.compress(original, 0, original.length, compressed, 0, compressed.length);
+
+        byte[] decompressed = new byte[original.length];
+        int decompressedSize = getDecompressor().decompress(compressed, 0, compressedSize, decompressed, 0, decompressed.length);
+
+        assertByteArraysEqual(original, 0, original.length, decompressed, 0, decompressedSize);
+    }
+
+    @Test(enabled = false)
+    public void testLargeRle()
+            throws IOException
+    {
+        // Dataset that produces an RLE block with 3-byte header
+
+        Compressor compressor = getCompressor();
+
+        byte[] original = readResource("data/zstd/large-rle");
+        int maxCompressLength = compressor.maxCompressedLength(original.length);
+
+        byte[] compressed = new byte[maxCompressLength];
+        int compressedSize = compressor.compress(original, 0, original.length, compressed, 0, compressed.length);
+
+        byte[] decompressed = new byte[original.length];
+        int decompressedSize = getDecompressor().decompress(compressed, 0, compressedSize, decompressed, 0, decompressed.length);
+
+        assertByteArraysEqual(original, 0, original.length, decompressed, 0, decompressedSize);
+    }
+
+    @Test(enabled = false)
+    public void testIncompressibleData()
+            throws IOException
+    {
+        // Incompressible data that would require more than maxCompressedLength(...) to store
+
+        Compressor compressor = getCompressor();
+
+        byte[] original = readResource("data/zstd/incompressible");
+        int maxCompressLength = compressor.maxCompressedLength(original.length);
+
+        byte[] compressed = new byte[maxCompressLength];
+        int compressedSize = compressor.compress(original, 0, original.length, compressed, 0, compressed.length);
+
+        byte[] decompressed = new byte[original.length];
+        int decompressedSize = getDecompressor().decompress(compressed, 0, compressedSize, decompressed, 0, decompressed.length);
+
+        assertByteArraysEqual(original, 0, original.length, decompressed, 0, decompressedSize);
+    }
+
+    @Test(enabled = false)
+    public void testMaxCompressedSize()
+    {
+        assertEquals(new ZstdCompressor().maxCompressedLength(0), 64);
+        assertEquals(new ZstdCompressor().maxCompressedLength(64 * 1024), 65_824);
+        assertEquals(new ZstdCompressor().maxCompressedLength(128 * 1024), 131_584);
+        assertEquals(new ZstdCompressor().maxCompressedLength(128 * 1024 + 1), 131_585);
+    }
+
+    // test over data sets, should the result depend on input size or its compressibility
+    @Test(enabled = false, dataProvider = "data")
+    public void testGetDecompressedSize(DataSet dataSet)
+    {
+        Compressor compressor = getCompressor();
+        byte[] originalUncompressed = dataSet.getUncompressed();
+        byte[] compressed = new byte[compressor.maxCompressedLength(originalUncompressed.length)];
+
+        int compressedLength = compressor.compress(originalUncompressed, 0, originalUncompressed.length, compressed, 0, compressed.length);
+
+        assertByteArraysEqual(compressed, 0, compressed.length, compressed, 0, compressed.length);
+
+        assertEquals(ZstdDecompressor.getDecompressedSize(compressed, 0, compressedLength), originalUncompressed.length);
+
+        int padding = 10;
+        byte[] compressedWithPadding = new byte[compressedLength + padding];
+        Arrays.fill(compressedWithPadding, (byte) 42);
+        System.arraycopy(compressed, 0, compressedWithPadding, padding, compressedLength);
+        assertEquals(ZstdDecompressor.getDecompressedSize(compressedWithPadding, padding, compressedLength), originalUncompressed.length);
+    }
+
+    @Test(enabled = false)
+    public void testVerifyMagicInAllFrames()
+            throws IOException
+    {
+        byte[] compressed = readResource("data/zstd/bad-second-frame.zst");
+        byte[] uncompressed = readResource("data/zstd/multiple-frames");
+        byte[] output = new byte[uncompressed.length];
+        assertThatThrownBy(() -> getDecompressor().decompress(compressed, 0, compressed.length, output, 0, output.length))
+                .isInstanceOf(MalformedInputException.class)
+                .hasMessageStartingWith("Invalid magic prefix");
+    }
+
+    @Test(enabled = false)
+    public void testDecompressIsMissingData()
+    {
+        byte[] input = new byte[]{40, -75, 47, -3, 32, 0, 1, 0};
+        byte[] output = new byte[1024];
+        assertThatThrownBy(() -> getDecompressor().decompress(input, 0, input.length, output, 0, output.length))
+                .matches(e -> e instanceof MalformedInputException || e instanceof UncheckedIOException)
+                .hasMessageContaining("Not enough input bytes");
+    }
+}

--- a/src/test/java/io/airlift/compress/zstd/TestZstdBb.java
+++ b/src/test/java/io/airlift/compress/zstd/TestZstdBb.java
@@ -26,6 +26,7 @@ import java.nio.ByteBuffer;
 import java.util.Arrays;
 
 import static io.airlift.compress.Util.readResource;
+import static io.airlift.compress.Util.readResourceBb;
 import static java.nio.ByteOrder.LITTLE_ENDIAN;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.testng.Assert.assertEquals;
@@ -42,7 +43,7 @@ public class TestZstdBb
     @Override
     protected Decompressor getDecompressor()
     {
-        return new ZstdDecompressor();
+        return new ZstdDecompressorBb();
     }
 
     @Override
@@ -188,14 +189,14 @@ public class TestZstdBb
         assertEquals(ZstdDecompressorBb.getDecompressedSize(compressedWithPadding, padding, compressedLength), originalUncompressed.length);
     }
 
-    @Test(enabled = false)
+    @Test
     public void testVerifyMagicInAllFrames()
             throws IOException
     {
-        byte[] compressed = readResource("data/zstd/bad-second-frame.zst");
-        byte[] uncompressed = readResource("data/zstd/multiple-frames");
-        byte[] output = new byte[uncompressed.length];
-        assertThatThrownBy(() -> getDecompressor().decompress(compressed, 0, compressed.length, output, 0, output.length))
+        ByteBuffer compressed = readResourceBb("data/zstd/bad-second-frame.zst");
+        ByteBuffer uncompressed = readResourceBb("data/zstd/multiple-frames");
+        ByteBuffer output = ByteBuffer.allocate(uncompressed.remaining()).order(LITTLE_ENDIAN);
+        assertThatThrownBy(() -> getDecompressor().decompress(compressed, output))
                 .isInstanceOf(MalformedInputException.class)
                 .hasMessageStartingWith("Invalid magic prefix");
     }

--- a/src/test/java/io/airlift/compress/zstd/TestZstdBb.java
+++ b/src/test/java/io/airlift/compress/zstd/TestZstdBb.java
@@ -201,12 +201,12 @@ public class TestZstdBb
                 .hasMessageStartingWith("Invalid magic prefix");
     }
 
-    @Test(enabled = false)
+    @Test
     public void testDecompressIsMissingData()
     {
-        byte[] input = new byte[]{40, -75, 47, -3, 32, 0, 1, 0};
-        byte[] output = new byte[1024];
-        assertThatThrownBy(() -> getDecompressor().decompress(input, 0, input.length, output, 0, output.length))
+        ByteBuffer input = ByteBuffer.wrap(new byte[]{40, -75, 47, -3, 32, 0, 1, 0});
+        ByteBuffer output = ByteBuffer.allocate(1024).order(LITTLE_ENDIAN);
+        assertThatThrownBy(() -> getDecompressor().decompress(input, output))
                 .matches(e -> e instanceof MalformedInputException || e instanceof UncheckedIOException)
                 .hasMessageContaining("Not enough input bytes");
     }


### PR DESCRIPTION
The next Java release intends to remove Unsafe, that current implementation depends on.

This is my attempt to remove the Unsafe usages, while keeping the rest of the code and APIs intact.